### PR TITLE
Added support for opening issues in the default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 * Setting up NPM can be real fun, or not real fun. You may need to use `sudo` for your installs on unix environments
 * If you run into permission issues, [Try This!](https://docs.npmjs.com/getting-started/fixing-npm-permissions)
   * Particularly changing ownership of your npm directory
-  
+
 ##Possible Issues with Jira Pal!
 * Yep, it's still young. If you encounter a bug, please add a github issue
-* If things seem to get totally borked, try running `jira logout`, `jira evict` and then re running `jira init`. 
+* If things seem to get totally borked, try running `jira logout`, `jira evict` and then re running `jira init`.
   * These are always safe bets to start over.
 
 ##Usage
@@ -40,10 +40,16 @@
   * Returns all stories you are assigned to, that fall under your default me statuses from `jira init`
 * `jira me foobar`
   * Returns all stories you are assigned to that search returns "foobar" for (i.e. search my stories)
+* `jira open`
+  * Select from issues assigned to you and open it in your default web browser.
+* `jira open XXX-123`
+  * Opens the issue in your default web browser.
+* `jira open -s foobar`
+  * Open an issue in your default web browser from ANY story that search returns for search criteria `foobar`
 * `jira copy`
   * Copy a story key (id) from the result set returned by `jira me`
 * `jira copy foobar`
-  * Copy a story id from ANY story that search returns for search critiera `foobar`
+  * Copy a story id from ANY story that search returns for search criteria `foobar`
 * `jira search`
   * Same as `jira me`
 * `jira search foobar`
@@ -54,9 +60,9 @@
   * Prime caches for various jira information that doesnt change often, like statuses
 * `jira evict`
   * Clear caches
-  
+
 ##Searching
- 
+
 * As noted in the examples above, `lookup` is the command you want to use to enter raw jql queries. There is an example using `jira help lookup`.
 * JQL is defined here on jiras website under [Advanced Searching](https://confluence.atlassian.com/jira/advanced-searching-179442050.html)
 * `search`, `me` and `copy` commands all search using "text contains ____" where the blank is whatever you type
@@ -70,7 +76,7 @@
   * This happens when you run `jira init`. Make your life easier and just run that command and follow the prompts
   * These settings will EXTEND `data/settings.js` meaning only keys present are over written
   * Make sure your `data/settings-override.js` exports a js object with desired settings
-  
+
 ###Current Settings Options
 
 * `url`: The url for your jira installation. `Required`

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
   "keywords": [],
   "dependencies": {
     "bluebird": "~2.10.0",
+    "cli-table": "~0.3.1",
+    "cliff": "~0.1.10",
+    "colors": "~1.1.2",
+    "copy-paste-no-exec": "git+ssh://git@github.com:Skiggz/node-copy-paste#1.0.0",
     "inquirer": "^0.10.0",
     "moment": "~2.10.3",
     "numeral": "~1.5.3",
+    "open": "0.0.5",
     "underscore": "~1.8.2",
-    "underscore.string": "~3.0.3",
-    "colors": "~1.1.2",
-    "cli-table": "~0.3.1",
-    "cliff": "~0.1.10",
-    "copy-paste-no-exec": "git+ssh://git@github.com:Skiggz/node-copy-paste#1.0.0"
+    "underscore.string": "~3.0.3"
   },
   "preferGlobal": true,
   "bin": {

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,0 +1,33 @@
+var _ = require('underscore');
+var _s = require('underscore.string');
+var print = require('../core/print');
+var meQueryOrSearch = require('../util/me-query-or-search');
+var settings = require('../data/settings');
+var selectIssue = require('../util/select-issue');
+var open = require('open');
+
+function openIssue(id) {
+    open(_s.sprintf('https://%s/browse/%s', settings.url, id));
+}
+
+module.exports = function() {
+    var args = Array.prototype.slice.call(arguments),
+        searchOrKey = args.shift();
+
+    if(!searchOrKey || searchOrKey == '-s') {
+        selectIssue(meQueryOrSearch.apply(this, _.toArray(arguments))).then(function(issue) {
+            if (!issue) {
+                print.info('No stories matched your search criteria');
+                return;
+            }
+            openIssue(issue.key);
+        }, function(e) {
+            print.fail('Failed to fetch issues ' + e ? e.message : '');
+        });
+    } else {
+        openIssue(searchOrKey);
+    }
+};
+
+module.exports.moduleDescription = 'Open specific issue or search with -s and select';
+module.exports.moduleDescriptionExtra = 'Example: jira open or jira open XXX-123 or jira open -s foobar';

--- a/src/util/select-issue.js
+++ b/src/util/select-issue.js
@@ -11,7 +11,7 @@ module.exports = function() {
             if (issues.length === 0) {
                 return resolve(null);
             }
-            var q = print.question('list', 'story', 'Select a story to copy the ID for');
+            var q = print.question('list', 'story', 'Select a story');
             _.each(issues, function(issue) {
                 q.choice(issue.key + ': ' + issue.summary());
             });


### PR DESCRIPTION
@Skiggz I added in support for `jira open`

Here are the options:
- `jira open` Lists issues assigned to you and allows you to select which one to open.
- `jira open XXX-123` allows you to open a specific story if you know the issue key.
- `jira open -s foobar` searches through all stories and allows you to select which one to open.  
