### PR TITLE
Added in watch/unwatch, describe and moved common logic to util.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ There is obviously a lot of enhancements coming, but I think the above commands 
 * `jira new`
   * Create a new issue (default fields only supported at the moment, more to come)
 * `jira board`
-  * View the sprint board for a selected rapid board. 
+  * View the sprint board for a selected rapid board.
   * You may pass -a to include all users (default is just your username)
   * Specify -p XXX to specify a rapid board by id (p for project, maybe not the best name)
 * `jira open`
@@ -83,6 +83,24 @@ There is obviously a lot of enhancements coming, but I think the above commands 
   * Add comment to the specified issue
 * `jira comment -s foobar`
   * Add comment to ANY story that search returns for search criteria `foobar`
+* `jira watch`
+  * Select from issues assigned to you to watch
+* `jira watch XXX-123`
+  * Watch the specified issue
+* `jira watch -s foobar`
+  * Watch ANY story that search returns for search criteria `foobar`
+* `jira unwatch`
+  * Select from issues assigned to you to stop watching
+* `jira unwatch XXX-123`
+  * Stop watching the specified issue
+* `jira unwatch -s foobar`
+  * Stop watching ANY story that search returns for search criteria `foobar`
+* `jira describe`
+  * Describe an issue assigned to you
+* `jira describe XXX-123`
+  * Describe a specific issue
+* `jira describe -s foobar`
+  * Describe ANY story that search returns for search criteria `foobar`
 * `jira copy`
   * Copy a story key (id) from the result set returned by `jira me`
 * `jira copy foobar`
@@ -111,7 +129,7 @@ There is obviously a lot of enhancements coming, but I think the above commands 
 
 * If you are using jira locally via pulling down the repo, and using the live version via npm you may want to:
   * Alias your local jira-pal jira.js file for ease of use
-  
+
 ##Settings
 
 * Default settings are stored in `data/settings.js`

--- a/src/commands/comment.js
+++ b/src/commands/comment.js
@@ -1,8 +1,7 @@
 var _ = require('underscore');
 var _s = require('underscore.string');
 var print = require('../core/print');
-var meQueryOrSearch = require('../util/me-query-or-search');
-var selectIssue = require('../util/select-issue');
+var meKeyOrSearch = require('../util/me-key-or-search');
 var api = require('../core/api');
 var vim = require('../util/jira-style-vim-fetch');
 
@@ -38,23 +37,11 @@ function comment(issueKey) {
 }
 
 module.exports = function() {
-    var args = Array.prototype.slice.call(arguments),
-        searchOrKey = args.shift();
-
-    if(!searchOrKey || searchOrKey == '-s') {
-        selectIssue(meQueryOrSearch.apply(this, _.toArray(arguments))).then(function(issue) {
-            if (!issue) {
-                print.info('No stories matched your search criteria');
-                return;
-            }
-
-            comment(issue.key);
-        }, function(e) {
-            print.fail('Failed to fetch issues ' + e ? e.message : '');
-        });
-    } else {
-        comment(searchOrKey);
-    }
+    meKeyOrSearch.apply(this, arguments)
+        .then(
+            comment,
+            _.noop
+        );
 };
 
 module.exports.moduleDescription = 'Comment on specific issue or search with -s and select, then enter in comments.';

--- a/src/commands/describe.js
+++ b/src/commands/describe.js
@@ -1,0 +1,25 @@
+var _ = require('underscore');
+var print = require('../core/print');
+var api = require('../core/api');
+var meKeyOrSearch = require('../util/me-key-or-search');
+
+function describe(keyOrId) {
+    api.issue(keyOrId).then(function(response) {
+        print.success('=============================================================================================');
+        print.success([response.data.key, ': ', response.data.summary()].join(''));
+        print.success('=============================================================================================');
+        print.success('');
+        print.success(response.data.description());
+    });
+}
+
+module.exports = function() {
+    meKeyOrSearch.apply(this, arguments)
+        .then(
+            describe,
+            _.noop
+        );
+};
+
+module.exports.moduleDescription = 'Description of an issue by key or id.';
+module.exports.moduleDescriptionExtra = 'Description of the issue request by key. Ex: `jira describe XXX-123` or `jira describe 100324`.';

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,9 +1,7 @@
-var _ = require('underscore');
 var _s = require('underscore.string');
-var print = require('../core/print');
-var meQueryOrSearch = require('../util/me-query-or-search');
+var _ = require('underscore');
 var settings = require('../data/settings');
-var selectIssue = require('../util/select-issue');
+var meKeyOrSearch = require('../util/me-key-or-search');
 var open = require('open');
 
 function openIssue(id) {
@@ -11,22 +9,11 @@ function openIssue(id) {
 }
 
 module.exports = function() {
-    var args = Array.prototype.slice.call(arguments),
-        searchOrKey = args.shift();
-
-    if(!searchOrKey || searchOrKey == '-s') {
-        selectIssue(meQueryOrSearch.apply(this, _.toArray(arguments))).then(function(issue) {
-            if (!issue) {
-                print.info('No stories matched your search criteria');
-                return;
-            }
-            openIssue(issue.key);
-        }, function(e) {
-            print.fail('Failed to fetch issues ' + e ? e.message : '');
-        });
-    } else {
-        openIssue(searchOrKey);
-    }
+    meKeyOrSearch.apply(this, arguments)
+        .then(
+            openIssue,
+            _.noop
+        );
 };
 
 module.exports.moduleDescription = 'Open specific issue or search with -s and select';

--- a/src/commands/unwatch.js
+++ b/src/commands/unwatch.js
@@ -1,0 +1,29 @@
+var _ = require('underscore');
+var _s = require('underscore.string');
+var print = require('../core/print');
+var meKeyOrSearch = require('../util/me-key-or-search');
+var api = require('../core/api');
+var vim = require('../util/jira-style-vim-fetch');
+
+function unwatch(issueKey) {
+    api.unwatch(issueKey)
+        .then(
+            function() {
+                print.success('You are no longer watching ' + issueKey);
+            },
+            function(e) {
+                print.error('There was a problem trying to unwatch ' + e ? e.message : '');
+            }
+        );
+}
+
+module.exports = function() {
+    meKeyOrSearch.apply(this, arguments)
+        .then(
+            unwatch,
+            _.noop
+        );
+};
+
+module.exports.moduleDescription = 'Stop watching a specific issue or search with -s and select';
+module.exports.moduleDescriptionExtra = 'Example: jira unwatch or jira unwatch XXX-123 or jira unwatch -s foobar';

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,0 +1,29 @@
+var _ = require('underscore');
+var _s = require('underscore.string');
+var print = require('../core/print');
+var meKeyOrSearch = require('../util/me-key-or-search');
+var api = require('../core/api');
+var vim = require('../util/jira-style-vim-fetch');
+
+function watch(issueKey) {
+    api.watch(issueKey)
+        .then(
+            function() {
+                print.success('You are now watching ' + issueKey);
+            },
+            function(e) {
+                print.error('There was a problem watching the issue ' + e ? e.message : '');
+            }
+        );
+}
+
+module.exports = function() {
+    meKeyOrSearch.apply(this, arguments)
+        .then(
+            watch,
+            _.noop
+        );
+};
+
+module.exports.moduleDescription = 'Watch specific issue or search with -s and select';
+module.exports.moduleDescriptionExtra = 'Example: jira watch or jira watch XXX-123 or jira watch -s foobar';

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -570,3 +570,11 @@ module.exports.getTransitions = function(issueIdOrKey) {
 module.exports.transition = function(issueIdOrKey, details) {
     return api('POST', _s.sprintf('/rest/api/2/issue/%s/transitions', issueIdOrKey), null, details);
 };
+
+module.exports.watch = function(issueIdOrKey) {
+    return api('POST', _s.sprintf('/rest/api/2/issue/%s/watchers', issueIdOrKey), null, settings.gett.username);
+};
+
+module.exports.unwatch = function(issueIdOrKey) {
+    return api('DELETE', _s.sprintf('/rest/api/2/issue/%s/watchers?username=%s', issueIdOrKey, settings.gett.username), null, null);
+};

--- a/src/models/fields.js
+++ b/src/models/fields.js
@@ -24,5 +24,6 @@ module.exports = function JiraFields(dataObject) {
     this.assignee = _.has(dataObject, 'assignee') ? new JiraUser(dataObject.assignee) : null;
     this.updated = _.has(dataObject, 'updated') ? new Date(dataObject.updated) : null;
     this.status = _.has(dataObject, 'status') ? new JiraStatus(dataObject.status) : null;
+    this.description = _.has(dataObject, 'description') ? dataObject.description : null;
 
 };

--- a/src/models/issue.js
+++ b/src/models/issue.js
@@ -25,6 +25,13 @@ module.exports = function JiraIssue(dataObject) {
         return '';
     };
 
+    this.description = function() {
+        if(self.fields && self.fields.description) {
+            return self.fields.description;
+        }
+        return '';
+    };
+
     this.status = function() {
         if (self.fields && self.fields.status) {
             return self.fields.status.name;

--- a/src/util/me-key-or-search.js
+++ b/src/util/me-key-or-search.js
@@ -1,0 +1,27 @@
+var Promise = require('bluebird');
+var _ = require('underscore');
+var print = require('../core/print');
+var meQueryOrSearch = require('../util/me-query-or-search');
+var selectIssue = require('../util/select-issue');
+
+module.exports = function() {
+    var args = Array.prototype.slice.call(arguments),
+        searchOrKey = args.shift();
+
+    return new Promise(function(resolve, reject) {
+        if(!searchOrKey || searchOrKey == '-s') {
+            selectIssue(meQueryOrSearch.apply(this, args)).then(function(issue) {
+                if (!issue) {
+                    print.info('No stories matched your search criteria');
+                    return reject();
+                }
+                resolve(issue.key);
+            }, function(e) {
+                print.fail('Failed to fetch issues ' + e ? e.message : '');
+                reject();
+            });
+        } else {
+            resolve(searchOrKey);
+        }
+    });
+};


### PR DESCRIPTION
@Skiggz 

Added in `watch` / `unwatch` and they work like `comment` and `open`. Since the logic started to become duplicated, I moved it into a single util.

Also, I added in `describe` which will show the key: summary and description of a story. That way you can easily see what is required of the story in the cli.
